### PR TITLE
Rename project flog => fwatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-name = "flog"
+name = "fwatch"
 version = "0.1.0"
 authors = ["Patrik Lundgren <patrik.lundgren.95@gmail.com>"]
 edition = "2018"
-default-run = "flogd"
+default-run = "fwatchd"
 
 [lib]
 name = "flib"
 path = "src/lib.rs"
 
 [[bin]]
-name = "flogctl"
-path = "src/flogctl.rs"
+name = "fwatchctl"
+path = "src/fwatchctl.rs"
 
 [[bin]]
-name = "flogd"
-path = "src/flogd.rs"
+name = "fwatchd"
+path = "src/fwatchd.rs"
 
 [dependencies]
 dirs = "3.0"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,1 @@
+sudo useradd -r fwatchd -d / -c fwatchd daemon -s /usr/bin/nologin

--- a/src/fwatchctl.rs
+++ b/src/fwatchctl.rs
@@ -5,10 +5,10 @@ use std::io::prelude::*;
 use std::os::unix::net::UnixStream;
 
 pub fn build() -> clap::Command<'static> {
-    let mut app = Command::new("flog - the forgetful file log.")
+    let mut app = Command::new("fwatch - the forgetful file log.")
         .version("2021")
         .author("Patrik Lundgren <patrik.lundgren.95@gmail.com>")
-        .about("flog has a short but excellent memory, it remembers file(s) by name and \n");
+        .about("fwatch has a short but excellent memory, it remembers file(s) by name and \n");
 
     app = app.subcommand(
         Command::new("track")

--- a/src/fwatchd.rs
+++ b/src/fwatchd.rs
@@ -24,8 +24,8 @@ use std::path::{Path, PathBuf};
 use std::sync::{atomic::AtomicBool, atomic::Ordering, Arc};
 use syslog::{BasicLogger, Facility, Formatter3164};
 
-const INDEX: &str = "/var/run/flog/index";
-const INDEXD: &str = "/var/run/flog/index.d";
+const INDEX: &str = "/var/run/fwatch/index";
+const INDEXD: &str = "/var/run/fwatch/index.d";
 
 pub fn load_index(workdir: &str) -> State {
     State::load(&format!("{workdir}/index")).unwrap_or_else(|_| State::new())
@@ -37,13 +37,13 @@ struct Args {
     /// Persistently try to setup a new inotify watch when IN_IGNORE event is received
     #[clap(short, long)]
     persistent: bool,
-    #[clap(long, default_value = "/var/run/flog.pid")]
+    #[clap(long, default_value = "/var/run/fwatch.pid")]
     pid_file: String,
-    #[clap(short, long, default_value = "flog")]
+    #[clap(short, long, default_value = "fwatch")]
     user: String,
-    #[clap(short, long, default_value = "flog")]
+    #[clap(short, long, default_value = "fwatch")]
     group: String,
-    #[clap(short, long, default_value = "/var/run/flog")]
+    #[clap(short, long, default_value = "/var/run/fwatch")]
     working_directory: String,
     #[clap(long)]
     foreground: bool,
@@ -325,7 +325,7 @@ fn main() {
     let formatter = Formatter3164 {
         facility: Facility::LOG_DAEMON,
         hostname: None,
-        process: "flog".into(),
+        process: "fwatch".into(),
         pid: 0,
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@ pub struct State {
     pub files: HashMap<String, Entry>,
 }
 
-pub const SOCK_PATH: &str = "/var/run/flogd.socket";
+pub const SOCK_PATH: &str = "/var/run/fwatchd.socket";
 
 impl State {
     pub fn load(f: &str) -> Result<State> {


### PR DESCRIPTION
The old name wasn't very indicative of the core functionality of the
project, i.e to watch files via the inotify API. Instead, it incorrectly
sort of indicated something more akin to syslog.

Signed-off-by: Patrik Lundgren <patrik.lundgren.95@gmail.com>